### PR TITLE
fix: rewrite viewBox to match scaled extent in ResponsiveGraph

### DIFF
--- a/bigraph_viz/test_responsive_svg.py
+++ b/bigraph_viz/test_responsive_svg.py
@@ -1,0 +1,54 @@
+"""Tests for ResponsiveGraph SVG post-processing.
+
+The critical invariant: the viewBox in the emitted SVG must cover ALL
+rendered geometry. Graphviz natively emits a viewBox sized to the
+UN-scaled extent while applying an inner transform="scale(s) ..." that
+pushes the post-scale extent past those bounds — causing right/bottom
+clipping in browsers and image viewers.
+"""
+import re
+
+from bigraph_viz import plot_bigraph
+
+
+def _make_responsive_svg() -> str:
+    state = {
+        'A': {'_type': 'process', 'inputs': {'in': ['store_a']}, 'outputs': {'out': ['store_b']}},
+        'B': {'_type': 'process', 'inputs': {'in': ['store_b']}, 'outputs': {'out': ['store_c']}},
+        'store_a': 1.0,
+        'store_b': 0.0,
+        'store_c': 0.0,
+    }
+    rg = plot_bigraph(state)
+    return rg._make_responsive_svg()
+
+
+def test_responsive_svg_is_width_100pct():
+    svg = _make_responsive_svg()
+    assert 'width="100%"' in svg
+    assert 'height="auto"' in svg
+
+
+def test_responsive_svg_viewbox_matches_scaled_extent():
+    """viewBox must equal the SVG's natural pt dimensions so all
+    transform-scaled content stays inside the rendered box.
+    """
+    svg = _make_responsive_svg()
+    # The post-rewrite SVG has width="100%" — we still want to confirm
+    # the viewBox matches the geometry. Re-pipe a fresh graphviz SVG
+    # to recover the unmodified width/height in pt for comparison.
+    from bigraph_viz import plot_bigraph as _pb
+    rg = _pb({'A': {'_type': 'process', 'inputs': {'in': ['s']}}, 's': 0.0})
+    raw = rg._graph.pipe(format='svg').decode()
+    wm = re.search(r'<svg[^>]*\bwidth="([0-9.]+)pt"', raw)
+    hm = re.search(r'<svg[^>]*\bheight="([0-9.]+)pt"', raw)
+    assert wm and hm, "raw graphviz SVG should have width=Npt height=Npt"
+    nat_w, nat_h = float(wm.group(1)), float(hm.group(1))
+
+    # Now check the responsive SVG's viewBox covers that extent.
+    fixed = rg._make_responsive_svg()
+    vbm = re.search(r'viewBox="([0-9.\-]+)\s+([0-9.\-]+)\s+([0-9.]+)\s+([0-9.]+)"', fixed)
+    assert vbm, "responsive SVG must keep a viewBox"
+    vb_w, vb_h = float(vbm.group(3)), float(vbm.group(4))
+    assert vb_w >= nat_w - 1e-3, f"viewBox width {vb_w} < scaled extent {nat_w}"
+    assert vb_h >= nat_h - 1e-3, f"viewBox height {vb_h} < scaled extent {nat_h}"

--- a/bigraph_viz/visualize_types.py
+++ b/bigraph_viz/visualize_types.py
@@ -33,6 +33,18 @@ class ResponsiveGraph:
         # Strip XML declaration and DOCTYPE so it can be embedded inline
         svg = re.sub(r'<\?xml[^?]*\?>\s*', '', svg)
         svg = re.sub(r'<!DOCTYPE[^>]*>\s*', '', svg)
+        # Fix the Graphviz viewBox/transform mismatch. Graphviz emits an
+        # inner <g transform="scale(s) translate(...)"> that scales content
+        # by s (typically ~1.39), but sets the viewBox to the UN-scaled
+        # extent. The post-scale content ends up beyond the viewBox bounds
+        # → right/bottom edges get clipped in browsers and image viewers.
+        # The SVG's width=Npt height=Npt attrs DO match the scaled extent,
+        # so we rewrite the viewBox to match before switching to width="100%".
+        wm = re.search(r'<svg[^>]*\bwidth="([0-9.]+)pt"', svg)
+        hm = re.search(r'<svg[^>]*\bheight="([0-9.]+)pt"', svg)
+        if wm and hm:
+            new_vb = 'viewBox="0 0 ' + wm.group(1) + ' ' + hm.group(1) + '"'
+            svg = re.sub(r'viewBox="[^"]+"', new_vb, svg, count=1)
         # Replace fixed width/height with 100% width and auto height
         svg = re.sub(
             r'<svg width="[^"]*" height="[^"]*"',


### PR DESCRIPTION
## Summary

Single-commit fix on top of v2.0.2: `ResponsiveGraph._make_responsive_svg` now rewrites the SVG's `viewBox` to match the natural pt dimensions before swapping width/height to responsive values. Right-edge / bottom-edge clipping of graph content goes away — without this fix the rightmost/bottommost nodes get cut off in browsers and image viewers.

## The bug

Graphviz emits SVG like:

```xml
<svg width="86pt" height="175pt" viewBox="0 0 62 126">
  <g transform="scale(1.389) translate(4 122)"> ... </g>
</svg>
```

The inner `<g transform="scale(1.389)">` scales geometry by ~1.39x, so post-scale content extends to ~86x175. But `viewBox` is `0 0 62 126` — anything past x=62 / y=126 lies outside the viewBox and gets clipped at the SVG edge.

The SVG's own `width="86pt" height="175pt"` attributes DO match the scaled extent (graphviz computes them post-scale). So the fix is straightforward: rewrite `viewBox` to `0 0 <width_pt> <height_pt>` before the existing width/height → "100%" / "auto" swap.

## Motivation

pbg-template's composite explorer (dashboard for process-bigraph research workspaces) hit this immediately after migrating to v2.0.0's `ResponsiveGraph` — diagrams looked broken with the right side of every graph cut off. Fixing it at the workspace layer is possible (re-pipe the SVG and rewrite viewBox) but every downstream consumer would have to discover and replicate the workaround.

## Test plan

- [x] `test_responsive_svg_is_width_100pct` — preserves existing v2.0.0 behavior (width="100%", height="auto")
- [x] `test_responsive_svg_viewbox_matches_scaled_extent` — viewBox width/height ≥ natural pt width/height (the invariant the fix establishes)

No API changes. No new params. Just makes the existing `ResponsiveGraph` not clip content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)